### PR TITLE
Update to 0.10.0-dev.4110+dfcadd22b

### DIFF
--- a/src/tokenizer.zig
+++ b/src/tokenizer.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const Location = @import("Location.zig");
 const GenericToken = @import("token.zig").Token;
 
-pub const Matcher = fn (str: []const u8) ?usize;
+pub const Matcher = std.meta.FnPtr(fn (str: []const u8) ?usize);
 
 pub fn Pattern(comptime TokenType: type) type {
     return struct {


### PR DESCRIPTION
If you want to keep stage1 compatibility this can be changed to use `std.meta.FnPtr(fn (str: []const u8) ?usize)` instead.